### PR TITLE
[FIX] Add check for `package.json`

### DIFF
--- a/bin/meta-yarn-link
+++ b/bin/meta-yarn-link
@@ -49,7 +49,14 @@ const packages = [];
 
 _.forEach(Object.keys(projects), (folder) => {
 
-  const childPackageJson = require(path.join(metaLocation, '..', folder, 'package.json'));
+  const childPackageJsonPath = path.join(metaLocation, '..', folder, 'package.json');
+
+  if (!fs.existsSync(childPackageJsonPath)) {
+    console.log(`\nNo package.json file found for ${folder}, skipping...`)
+    return;
+  }
+
+  const childPackageJson = require(childPackageJsonPath);
 
   if (all) {
     metaPackageJson.dependencies[childPackageJson.name] = null;


### PR DESCRIPTION
In a metarepo where some packages are node packages, and others are not, `meta yarn link` will crash if it can't find a `package.json` in the metarepo.  This checks if `package.json` exists before trying to read it.