### PR TITLE
Upgrade linked

### DIFF
--- a/bin/meta-yarn
+++ b/bin/meta-yarn
@@ -11,6 +11,7 @@ program
   .command('clean', 'delete the node_modules folder in meta and child repositories')
   .command('install', 'yarn install meta and child repositories')
   .command('link [--all]', 'yarn link child repositories where used within child and meta repositories')
+  .command('upgrade-linked <version>', 'upgrades linked repositories with the provided version/commit')
   .parse(process.argv);
 
 loaded = true;

--- a/bin/meta-yarn-upgrade-linked
+++ b/bin/meta-yarn-upgrade-linked
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const program = require('commander');
+const debug = require('debug')('meta-yarn-install');
+const getMetaFile = require('get-meta-file');
+const loop = require('loop');
+const path = require('path');
+const util = require('util');
+const metaLocation = path.join(process.cwd(), '.meta');
+const getPackageDependencies = require('../lib/getPackageDependencies');
+
+if (process.argv.length !== 3 || process.argv[2] === '--help') {
+  return console.log(`\n  usage:\n\n    meta yarn upgrade-linked <version>\n`);
+}
+
+const version = process.argv[2];
+
+try {
+  buffer = fs.readFileSync(metaLocation);
+  debug(`.meta file found at ${metaLocation}`);
+} catch (e) {
+  debug(`no .meta file found at ${metaLocation}: ${e}`);
+}
+
+const meta = getMetaFile();
+const projects = meta.projects;
+
+const packages = [];
+
+Object.keys(projects).forEach(project => {
+  const folder = path.resolve(project);
+  const packagePath = path.resolve(metaLocation, '..', folder, 'package.json');
+  const childPackageJson = require(packagePath);
+
+  packages.push({
+    name: childPackageJson.name,
+    gitRef: projects[project],
+    folder,
+    packagePath,
+    dependencies: [
+      ...Object.keys(childPackageJson.dependencies || {}),
+      ...Object.keys(childPackageJson.devDependencies || {}),
+    ],
+  });
+});
+
+const packageNames = packages.map(package => package.name);
+const installDirs = [];
+
+packages
+  .filter(package => package.dependencies.some(d => packageNames.includes(d)))
+  .forEach(package => {
+    const childPackageJson = require(package.packagePath);
+
+    packages
+      .filter(
+        packageDep =>
+          (childPackageJson.dependencies && childPackageJson.dependencies[packageDep.name]) ||
+          (childPackageJson.devDependencies && childPackageJson.devDependencies[packageDep.name])
+      )
+      .forEach(packageDep => {
+        const newRef = `git+ssh://${packageDep.gitRef}#${version}`;
+        
+
+        if (childPackageJson.dependencies && childPackageJson.dependencies[packageDep.name]) {
+          console.log(`Updating ${package.name} reference to ${packageDep.name}.`);
+          childPackageJson.dependencies[packageDep.name] = newRef;
+        }
+
+        if (childPackageJson.devDependencies && childPackageJson.devDependencies[packageDep.name]) {
+          console.log(`Updating ${package.name} reference to ${packageDep.name}.`);
+          childPackageJson.devDependencies[packageDep.name] = newRef;
+        }
+      });
+
+    fs.writeFileSync(package.packagePath, JSON.stringify(childPackageJson, null, 2));
+    installDirs.push(package.folder);
+  });
+
+  // run install on each folder to update yarn.lock
+  loop({
+    command: 'yarn install', 
+    directories: installDirs
+  })

--- a/bin/meta-yarn-upgrade-linked
+++ b/bin/meta-yarn-upgrade-linked
@@ -74,7 +74,7 @@ packages
         }
       });
 
-    fs.writeFileSync(package.packagePath, JSON.stringify(childPackageJson, null, 2));
+    fs.writeFileSync(package.packagePath, `${JSON.stringify(childPackageJson, null, 2)}${require('os').EOL}`);
     installDirs.push(package.folder);
   });
 


### PR DESCRIPTION
Adds support for updating linked package references with a given version, so if `foo` and `bar` are in the same meta project, and `foo` references `bar` in package.json, then that reference becomes `"foo": "git+ssh://...bar.git#version"`.
 